### PR TITLE
Add a -r (--reverse) option to convert usernames to emails.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,104 @@
+# PyCharm development
+.idea/
+
+## GitHub default python project entries past this point
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/example-config.yml
+++ b/example-config.yml
@@ -1,5 +1,5 @@
-org_id: [ORG ID]
-tech_acct_id: [TECH ACCT ID]
-api_key: [API KEY]
-client_secret: [CLIENT SECRET]
-private_key_file: [PATH TO PRIVATE KEY]
+org_id: 'ORG_ID'
+tech_acct_id: 'TECH_ACCT_ID'
+api_key: 'API_KEY'
+client_secret: 'CLIENT_SECRET'
+private_key_file: 'PATH_TO_PRIVATE_KEY'

--- a/example-users-export.csv
+++ b/example-users-export.csv
@@ -1,0 +1,4 @@
+Identity Type,Username,Domain,Email,First Name,Last Name,Country Code,Product Configurations,Admin Roles,Product Configurations Administered
+Federated ID,dbrotsky-test-1,ad.unc.edu,dbrotsky-test-1@ad.unc.edu,Dan Test 1,Brotsky,US,Instructional Faculty/Staff,,
+Federated ID,dbrotsky-test-2,ad.unc.edu,dbrotsky-test-2@ad.unc.edu,Dan Test 2,Brotsky,US,Student,,
+Federated ID,918272819,ad.unc.edu,dbrotsky-test-3@ad.unc.edu,Dan Test 3,Brotsky,US,Departmental Faculty/Staff,,

--- a/example-users-simple.csv
+++ b/example-users-simple.csv
@@ -1,4 +1,4 @@
 Username,Email
 dbrotsky-test-1,dbrotsky-test-1@ad.unc.edu
 dbrotsky-test-2,dbrotsky-test-2@ad.unc.edu
-
+918272819,dbrotsky-test-3@ad.unc.edu

--- a/example-users.csv
+++ b/example-users.csv
@@ -1,0 +1,4 @@
+Username,Email
+dbrotsky-test-1,dbrotsky-test-1@ad.unc.edu
+dbrotsky-test-2,dbrotsky-test-2@ad.unc.edu
+

--- a/user_update.py
+++ b/user_update.py
@@ -16,11 +16,16 @@ if __name__ == '__main__':
     parser.add_argument('-u', '--users',
                         help='filename of user file',
                         metavar='filename', dest='users_filename')
-    parser.add_argument('-t',
+    parser.add_argument('-t', '--test-mode',
                         help='run updates in test mode',
                         dest='test_mode',
                         action='store_true',
                         default=False)
+    parser.add_argument('-r', '--reverse',
+                        help='reverse conversion (go from username to email, rather than email to username)',
+                        dest='from_email',
+                        action='store_false',
+                        default=True)
 
     args = parser.parse_args()
 
@@ -31,21 +36,29 @@ if __name__ == '__main__':
                                    test_mode=args.test_mode,
                                    logger=logger)
 
-    cols = ['Identity Type', 'Username', 'Domain', 'Email', 'First Name', 'Last Name', 'Country Code',
-            'Product Configurations', 'Admin Roles', 'Product Configurations Administered']
+    cols = ['Username', 'Email']
 
     actions = {}
     for user_rec in CSVAdapter.read_csv_rows(args.users_filename, recognized_column_names=cols):
-        user = UserAction(id_type=IdentityTypes.federatedID, email=user_rec['Email'])
-        user.update(username=user_rec['Username'])
-        res = conn.execute_single(user)
-        logger.debug("Updating %s -- queued, sent, completed %s" % (user_rec['Email'], res))
-        actions[user_rec['Email']] = user
+        username, email = user_rec['Username'], user_rec['Email']
+        if args.from_email:
+            user = UserAction(id_type=IdentityTypes.federatedID, email=email)
+            user.update(username=username)
+            actions[email] = user
+        else:
+            domain = email[email.index('@') + 1:]
+            user = UserAction(id_type=IdentityTypes.federatedID, username=username, domain=domain)
+            user.update(username=email)
+            actions[username] = user
+        conn.execute_single(user)
 
     conn.execute_queued()
 
-    for email, action in actions.items():
+    successes, failures = 0, 0
+    for key, action in actions.items():
         if not action.execution_errors():
-            logger.debug("%s - updated successfully" % email)
+            successes += 1
         else:
-            logger.debug("%s - ERROR - %s" % (email, action.execution_errors()))
+            failures += 1
+            logger.error("Conversion of %s failed: %s" % (key, action.execution_errors()))
+    logger.info("Conversions attempted/succeeded/failed: %d/%d/%d" % (len(actions), successes, failures))

--- a/user_update.py
+++ b/user_update.py
@@ -40,14 +40,15 @@ if __name__ == '__main__':
 
     actions = {}
     for user_rec in CSVAdapter.read_csv_rows(args.users_filename, recognized_column_names=cols):
-        username, email = user_rec['Username'], user_rec['Email']
+        username, email = user_rec.get('Username'), user_rec.get('Email')
+        if not username or not email:
+            logger.warning("Skipping input record with missing Username and/or Email: %s" % user_rec)
+            continue
+        user = UserAction(id_type=IdentityTypes.federatedID, email=email)
         if args.from_email:
-            user = UserAction(id_type=IdentityTypes.federatedID, email=email)
             user.update(username=username)
             actions[email] = user
         else:
-            domain = email[email.index('@') + 1:]
-            user = UserAction(id_type=IdentityTypes.federatedID, username=username, domain=domain)
             user.update(username=email)
             actions[username] = user
         conn.execute_single(user)


### PR DESCRIPTION
* It's kind of hard to test this running in only one direction.  Now you can run it backwards.
* Also added a sample users file, and only specified the columns we actually use.
* Also simplified the logging, so we don't report successes verbosely, and we give a count.

I've sent you some integration credentials to make it easier to test.